### PR TITLE
add dockerfile to build test suites into container image for kubernet…

### DIFF
--- a/load-testing-v2/Dockerfile
+++ b/load-testing-v2/Dockerfile
@@ -1,0 +1,12 @@
+# Use the official k6 image as the base
+FROM grafana/k6:latest
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the k6 test script from your host machine to the container
+COPY ./tests/ .
+COPY ./utils/ .
+
+# Define the command to run the test when the container starts
+ENTRYPOINT ["k6", "run", "/app/tests/audit-service/audit-login.js"]


### PR DESCRIPTION
Add dockerfile to build on top of k6 base layer with test suites for k8s deployment.  Otherwise, you would need to manage test suites via volume mounts and configmaps for JS files.